### PR TITLE
Remove misleading example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ At this time the API is in an early preview state to obtain feedback from the co
 
 ## Usage
 
-You can use this API as a dependency via the public Hypixel maven repo. You can also use
-the [Example Code](https://github.com/HypixelDev/PublicAPI/tree/master/hypixel-api-example) as a good starting point.
+You can use this API as a dependency via the public Hypixel maven repo.
 
 #### Hypixel Maven Repo
 


### PR DESCRIPTION
This example code message was copied over from https://github.com/HypixelDev/PublicAPI/blob/master/README.md
It's misleading, making developers think you need to use the public api.