### PR TITLE
Remove getInstance()

### DIFF
--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -22,7 +22,7 @@ public class HypixelModAPI {
     private final PacketRegistry registry = new PacketRegistry();
     private final List<ClientboundPacketHandler> handlers = new CopyOnWriteArrayList<>();
 
-    private HypixelModAPI() {
+    public HypixelModAPI() {
         registry.registerPacketType("hypixel:ping",
                 ClientboundPingPacket.class, ClientboundPingPacket::new,
                 ServerboundPingPacket.class, ServerboundPingPacket::new);

--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -19,12 +19,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class HypixelModAPI {
-    private static final HypixelModAPI INSTANCE = new HypixelModAPI();
-
-    public static HypixelModAPI getInstance() {
-        return INSTANCE;
-    }
-
     private final PacketRegistry registry = new PacketRegistry();
     private final List<ClientboundPacketHandler> handlers = new CopyOnWriteArrayList<>();
 

--- a/src/main/java/net/hypixel/modapi/packet/HypixelPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/HypixelPacket.java
@@ -1,14 +1,13 @@
 package net.hypixel.modapi.packet;
 
-import net.hypixel.modapi.HypixelModAPI;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
 public interface HypixelPacket {
 
     void write(PacketSerializer serializer);
 
-    default String getIdentifier() {
-        return HypixelModAPI.getInstance().getRegistry().getIdentifier(getClass());
+    default String getIdentifier(PacketRegistry registry) {
+        return registry.getIdentifier(getClass());
     }
 
 }

--- a/src/test/java/net/hypixe/modapi/TestPacketIdentifierLength.java
+++ b/src/test/java/net/hypixe/modapi/TestPacketIdentifierLength.java
@@ -7,9 +7,12 @@ import org.junit.jupiter.api.Test;
 public class TestPacketIdentifierLength {
     private static final int LIMIT = 20;
 
+    private static final HypixelModAPI MOD_API = new HypixelModAPI();
+
     @Test
     void testPacketIdentifierLength() {
-        for (String identifier : HypixelModAPI.getInstance().getRegistry().getIdentifiers()) {
+
+        for (String identifier : MOD_API.getRegistry().getIdentifiers()) {
             Assertions.assertTrue(identifier.length() <= LIMIT, String.format("Identifier %s is too long (length %d)", identifier, identifier.length()));
         }
     }


### PR DESCRIPTION
We should declare the instance ourselves, in order to be able to unregister the HypixelModAPI when not on hypixel.
Sadly Hypixel is not the only server.