### PR TITLE
Add method to deregister handlers

### DIFF
--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -3,6 +3,7 @@ package net.hypixel.modapi;
 import net.hypixel.modapi.error.ErrorReason;
 import net.hypixel.modapi.error.ModAPIException;
 import net.hypixel.modapi.handler.ClientboundPacketHandler;
+import net.hypixel.modapi.handler.RegisteredHandler;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 import net.hypixel.modapi.packet.PacketRegistry;
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundLocationPacket;
@@ -47,8 +48,9 @@ public class HypixelModAPI {
         return registry;
     }
 
-    public void registerHandler(ClientboundPacketHandler handler) {
+    public RegisteredHandler registerHandler(ClientboundPacketHandler handler) {
         handlers.add(handler);
+        return new RegisteredHandlerImpl(handlers, handler);
     }
 
     public void handle(String identifier, PacketSerializer serializer) {

--- a/src/main/java/net/hypixel/modapi/RegisteredHandlerImpl.java
+++ b/src/main/java/net/hypixel/modapi/RegisteredHandlerImpl.java
@@ -1,0 +1,27 @@
+package net.hypixel.modapi;
+
+import net.hypixel.modapi.handler.ClientboundPacketHandler;
+import net.hypixel.modapi.handler.RegisteredHandler;
+
+import java.util.List;
+
+final class RegisteredHandlerImpl implements RegisteredHandler {
+    private final List<ClientboundPacketHandler> handlers;
+    private final ClientboundPacketHandler handler;
+    private volatile boolean deregistered;
+
+    RegisteredHandlerImpl(List<ClientboundPacketHandler> handlers, ClientboundPacketHandler handler) {
+        this.handlers = handlers;
+        this.handler = handler;
+    }
+
+    @Override
+    public void deregister() {
+        if (deregistered) return;
+        synchronized (this) {
+            if (deregistered) return;
+            deregistered = true;
+        }
+        handlers.remove(handler);
+    }
+}

--- a/src/main/java/net/hypixel/modapi/handler/RegisteredHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/RegisteredHandler.java
@@ -1,0 +1,6 @@
+package net.hypixel.modapi.handler;
+
+public interface RegisteredHandler {
+
+    void deregister();
+}


### PR DESCRIPTION
Basically the same as #12, but the solution is, in my opinion, cleaner.
To deregister a handler, one could simply call `RegisteredHandler#deregister`.
I think this is better because this approach provides better encapsulation.