### PR TITLE
improvement: Change packet handling to only handle the expected version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ At this time the API is in an early preview state to obtain feedback from the co
 
 ## Usage
 
+For using the Mod API it is highly recommended to relocate the package `net.hypixel` to prevent conflicting with other mods and different versions of the Mod API.
+
 You can use this API as a dependency via the public Hypixel maven repo.
 
 #### Hypixel Maven Repo

--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -5,6 +5,7 @@ import net.hypixel.modapi.error.ModAPIException;
 import net.hypixel.modapi.handler.ClientboundPacketHandler;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 import net.hypixel.modapi.packet.PacketRegistry;
+import net.hypixel.modapi.packet.impl.VersionedPacket;
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundLocationPacket;
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundPartyInfoPacket;
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundPingPacket;
@@ -71,6 +72,11 @@ public class HypixelModAPI {
         }
 
         ClientboundHypixelPacket packet = registry.createClientboundPacket(identifier, serializer);
+        if (packet instanceof VersionedPacket && !((VersionedPacket) packet).isExpectedVersion()) {
+            // Ignore packets that don't match our expected version, these could be received due to other mods requesting them
+            return;
+        }
+
         for (ClientboundPacketHandler handler : handlers) {
             packet.handle(handler);
         }

--- a/src/main/java/net/hypixel/modapi/packet/impl/VersionedPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/VersionedPacket.java
@@ -3,15 +3,26 @@ package net.hypixel.modapi.packet.impl;
 import net.hypixel.modapi.packet.HypixelPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
+/**
+ * Represents a packet that is backed by a version. Versioned packets will only be handled if the incoming packet matches the version of the packet known.
+ */
 public abstract class VersionedPacket implements HypixelPacket {
-    private final int version;
+    private int version;
 
     public VersionedPacket(int version) {
         this.version = version;
     }
 
-    public VersionedPacket(PacketSerializer byteBuf) {
-        this.version = byteBuf.readVarInt();
+    public VersionedPacket(PacketSerializer serializer) {
+        read(serializer);
+    }
+
+    /**
+     * @return true if reading was successful, false if otherwise (such as due to a mismatch in version)
+     */
+    protected boolean read(PacketSerializer serializer) {
+        this.version = serializer.readVarInt();
+        return isExpectedVersion();
     }
 
     @Override
@@ -21,6 +32,12 @@ public abstract class VersionedPacket implements HypixelPacket {
 
     public int getVersion() {
         return version;
+    }
+
+    protected abstract int getLatestVersion();
+
+    public boolean isExpectedVersion() {
+        return getVersion() == getLatestVersion();
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundLocationPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundLocationPacket.java
@@ -13,17 +13,17 @@ import java.util.Optional;
 public class ClientboundLocationPacket extends VersionedPacket implements ClientboundHypixelPacket {
     private static final int CURRENT_VERSION = 1;
 
-    private final Environment environment;
-    private final String proxyName;
-    private final String serverName;
+    private Environment environment;
+    private String proxyName;
+    private String serverName;
     @Nullable
-    private final ServerType serverType;
+    private ServerType serverType;
     @Nullable
-    private final String lobbyName;
+    private String lobbyName;
     @Nullable
-    private final String mode;
+    private String mode;
     @Nullable
-    private final String map;
+    private String map;
 
     public ClientboundLocationPacket(Environment environment, String proxyName, String serverName, @Nullable ServerType serverType, @Nullable String lobbyName, @Nullable String mode, @Nullable String map) {
         super(CURRENT_VERSION);
@@ -38,6 +38,14 @@ public class ClientboundLocationPacket extends VersionedPacket implements Client
 
     public ClientboundLocationPacket(PacketSerializer serializer) {
         super(serializer);
+    }
+
+    @Override
+    protected boolean read(PacketSerializer serializer) {
+        if (!super.read(serializer)) {
+            return false;
+        }
+
         this.environment = Environment.getById(serializer.readVarInt()).orElseThrow(() -> new IllegalArgumentException("Invalid environment ID"));
         this.proxyName = serializer.readString();
         this.serverName = serializer.readString();
@@ -45,6 +53,7 @@ public class ClientboundLocationPacket extends VersionedPacket implements Client
         this.lobbyName = serializer.readOptionally(PacketSerializer::readString);
         this.mode = serializer.readOptionally(PacketSerializer::readString);
         this.map = serializer.readOptionally(PacketSerializer::readString);
+        return true;
     }
 
     @Override
@@ -57,6 +66,11 @@ public class ClientboundLocationPacket extends VersionedPacket implements Client
         serializer.writeOptionally(lobbyName, PacketSerializer::writeString);
         serializer.writeOptionally(mode, PacketSerializer::writeString);
         serializer.writeOptionally(map, PacketSerializer::writeString);
+    }
+
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
@@ -11,9 +11,9 @@ import java.util.*;
 public class ClientboundPartyInfoPacket extends VersionedPacket implements ClientboundHypixelPacket {
     private static final int CURRENT_VERSION = 1;
 
-    private final boolean inParty;
-    private final UUID leader;
-    private final Set<UUID> members;
+    private boolean inParty;
+    private UUID leader;
+    private Set<UUID> members;
 
     public ClientboundPartyInfoPacket(boolean inParty, @Nullable UUID leader, Set<UUID> members) {
         super(CURRENT_VERSION);
@@ -24,12 +24,19 @@ public class ClientboundPartyInfoPacket extends VersionedPacket implements Clien
 
     public ClientboundPartyInfoPacket(PacketSerializer serializer) {
         super(serializer);
+    }
+
+    @Override
+    protected boolean read(PacketSerializer serializer) {
+        if (!super.read(serializer)) {
+            return false;
+        }
 
         this.inParty = serializer.readBoolean();
         if (!inParty) {
             this.leader = null;
             this.members = Collections.emptySet();
-            return;
+            return true;
         }
 
         this.leader = serializer.readUuid();
@@ -39,6 +46,7 @@ public class ClientboundPartyInfoPacket extends VersionedPacket implements Clien
             members.add(serializer.readUuid());
         }
         this.members = Collections.unmodifiableSet(members);
+        return true;
     }
 
     @Override
@@ -54,6 +62,11 @@ public class ClientboundPartyInfoPacket extends VersionedPacket implements Clien
         for (UUID member : members) {
             serializer.writeUuid(member);
         }
+    }
+
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPingPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPingPacket.java
@@ -8,7 +8,7 @@ import net.hypixel.modapi.serializer.PacketSerializer;
 public class ClientboundPingPacket extends VersionedPacket implements ClientboundHypixelPacket {
     private static final int CURRENT_VERSION = 1;
 
-    private final String response;
+    private String response;
 
     public ClientboundPingPacket(String response) {
         super(CURRENT_VERSION);
@@ -17,13 +17,27 @@ public class ClientboundPingPacket extends VersionedPacket implements Clientboun
 
     public ClientboundPingPacket(PacketSerializer serializer) {
         super(serializer);
+    }
+
+    @Override
+    protected boolean read(PacketSerializer serializer) {
+        if (!super.read(serializer)) {
+            return false;
+        }
+
         this.response = serializer.readString();
+        return true;
     }
 
     @Override
     public void write(PacketSerializer serializer) {
         super.write(serializer);
         serializer.writeString(response);
+    }
+
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPlayerInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPlayerInfoPacket.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 public class ClientboundPlayerInfoPacket extends VersionedPacket implements ClientboundHypixelPacket {
     private static final int CURRENT_VERSION = 1;
 
-    private final PlayerRank playerRank;
-    private final PackageRank packageRank;
-    private final MonthlyPackageRank monthlyPackageRank;
+    private PlayerRank playerRank;
+    private PackageRank packageRank;
+    private MonthlyPackageRank monthlyPackageRank;
     @Nullable
-    private final String prefix;
+    private String prefix;
 
     public ClientboundPlayerInfoPacket(PlayerRank playerRank, PackageRank packageRank, MonthlyPackageRank monthlyPackageRank, @Nullable String prefix) {
         super(CURRENT_VERSION);
@@ -30,10 +30,19 @@ public class ClientboundPlayerInfoPacket extends VersionedPacket implements Clie
 
     public ClientboundPlayerInfoPacket(PacketSerializer serializer) {
         super(serializer);
+    }
+
+    @Override
+    protected boolean read(PacketSerializer serializer) {
+        if (!super.read(serializer)) {
+            return false;
+        }
+
         this.playerRank = PlayerRank.getById(serializer.readVarInt()).orElseThrow(() -> new IllegalArgumentException("Invalid player rank ID"));
         this.packageRank = PackageRank.getById(serializer.readVarInt()).orElseThrow(() -> new IllegalArgumentException("Invalid package rank ID"));
         this.monthlyPackageRank = MonthlyPackageRank.getById(serializer.readVarInt()).orElseThrow(() -> new IllegalArgumentException("Invalid monthly package rank ID"));
         this.prefix = serializer.readOptionally(PacketSerializer::readString);
+        return true;
     }
 
     @Override
@@ -43,6 +52,11 @@ public class ClientboundPlayerInfoPacket extends VersionedPacket implements Clie
         serializer.writeVarInt(packageRank.getId());
         serializer.writeVarInt(monthlyPackageRank.getId());
         serializer.writeOptionally(prefix, PacketSerializer::writeString);
+    }
+
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundLocationPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundLocationPacket.java
@@ -14,4 +14,9 @@ public class ServerboundLocationPacket extends VersionedPacket {
         super(serializer);
     }
 
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
+    }
+
 }

--- a/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPartyInfoPacket.java
@@ -14,4 +14,9 @@ public class ServerboundPartyInfoPacket extends VersionedPacket {
         super(serializer);
     }
 
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
+    }
+
 }

--- a/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPingPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPingPacket.java
@@ -14,4 +14,9 @@ public class ServerboundPingPacket extends VersionedPacket {
         super(serializer);
     }
 
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
+    }
+
 }

--- a/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPlayerInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPlayerInfoPacket.java
@@ -14,4 +14,9 @@ public class ServerboundPlayerInfoPacket extends VersionedPacket {
         super(serializer);
     }
 
+    @Override
+    protected int getLatestVersion() {
+        return CURRENT_VERSION;
+    }
+
 }


### PR DESCRIPTION
Originally I hoped to use the versioning for some form of backward compatibility, but due to different versions of packets potentially resulting in different behavior, this could have unexpected consequences. This change results in us only reading and handling packets that we "understand" based on the current version, so if the primary packet handler receives an old or new packet then it will simply stop reading after the version and not invoke the registered handlers.