### PR TITLE
Implement party_info version 2 with party role

### DIFF
--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
@@ -58,6 +58,7 @@ public class ClientboundPartyInfoPacket extends ClientboundVersionedPacket {
                 return;
             }
 
+            serializer.writeBoolean(true);
             serializer.writeUuid(leader.get());
             Set<UUID> members = getMembers();
             serializer.writeVarInt(members.size());

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
@@ -1,25 +1,24 @@
 package net.hypixel.modapi.packet.impl.clientbound;
 
 import net.hypixel.modapi.handler.ClientboundPacketHandler;
-import net.hypixel.modapi.packet.ClientboundHypixelPacket;
-import net.hypixel.modapi.packet.impl.VersionedPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
 public class ClientboundPartyInfoPacket extends ClientboundVersionedPacket {
-    private static final int CURRENT_VERSION = 1;
+    private static final int CURRENT_VERSION = 2;
 
     private boolean inParty;
-    private UUID leader;
-    private Set<UUID> members;
+    private Map<UUID, PartyMember> memberMap;
 
-    public ClientboundPartyInfoPacket(boolean inParty, @Nullable UUID leader, Set<UUID> members) {
-        super(CURRENT_VERSION);
+    public ClientboundPartyInfoPacket(int version, boolean inParty, Map<UUID, PartyMember> memberMap) {
+        super(version);
+        if (version > CURRENT_VERSION) {
+            throw new IllegalArgumentException("Version " + version + " is greater than the current version " + CURRENT_VERSION);
+        }
+
         this.inParty = inParty;
-        this.leader = leader;
-        this.members = members;
+        this.memberMap = memberMap;
     }
 
     public ClientboundPartyInfoPacket(PacketSerializer serializer) {
@@ -34,33 +33,48 @@ public class ClientboundPartyInfoPacket extends ClientboundVersionedPacket {
 
         this.inParty = serializer.readBoolean();
         if (!inParty) {
-            this.leader = null;
-            this.members = Collections.emptySet();
+            this.memberMap = Collections.emptyMap();
             return true;
         }
 
-        this.leader = serializer.readUuid();
         int memberCount = serializer.readVarInt();
-        Set<UUID> members = new HashSet<>(memberCount);
+        Map<UUID, PartyMember> memberMap = new HashMap<>(memberCount);
         for (int i = 0; i < memberCount; i++) {
-            members.add(serializer.readUuid());
+            PartyMember member = new PartyMember(serializer);
+            memberMap.put(member.getUuid(), member);
         }
-        this.members = Collections.unmodifiableSet(members);
+        this.memberMap = Collections.unmodifiableMap(memberMap);
         return true;
     }
 
     @Override
     public void write(PacketSerializer serializer) {
         super.write(serializer);
+
+        if (version == 1) {
+            Optional<UUID> leader = getLeader();
+            if (!leader.isPresent()) {
+                serializer.writeBoolean(false);
+                return;
+            }
+
+            serializer.writeUuid(leader.get());
+            Set<UUID> members = getMembers();
+            serializer.writeVarInt(members.size());
+            for (UUID member : members) {
+                serializer.writeUuid(member);
+            }
+            return;
+        }
+
         serializer.writeBoolean(inParty);
         if (!inParty) {
             return;
         }
 
-        serializer.writeUuid(leader);
-        serializer.writeVarInt(members.size());
-        for (UUID member : members) {
-            serializer.writeUuid(member);
+        serializer.writeVarInt(memberMap.size());
+        for (PartyMember member : memberMap.values()) {
+            member.write(serializer);
         }
     }
 
@@ -79,19 +93,73 @@ public class ClientboundPartyInfoPacket extends ClientboundVersionedPacket {
     }
 
     public Optional<UUID> getLeader() {
-        return Optional.ofNullable(leader);
+        if (!inParty) {
+            return Optional.empty();
+        }
+        return memberMap.values().stream()
+                .filter(member -> member.getRole() == PartyRole.LEADER)
+                .map(PartyMember::getUuid)
+                .findFirst();
     }
 
     public Set<UUID> getMembers() {
-        return members;
+        return memberMap.keySet();
+    }
+
+    public Map<UUID, PartyMember> getMemberMap() {
+        return memberMap;
     }
 
     @Override
     public String toString() {
         return "ClientboundPartyInfoPacket{" +
                 "inParty=" + inParty +
-                ", leader=" + leader +
-                ", members=" + members +
+                ", memberMap=" + memberMap +
                 "} " + super.toString();
+    }
+
+    public static class PartyMember {
+        private final UUID uuid;
+        private final PartyRole role;
+
+        public PartyMember(UUID uuid, PartyRole role) {
+            this.uuid = uuid;
+            this.role = role;
+        }
+
+        PartyMember(PacketSerializer serializer) {
+            this.uuid = serializer.readUuid();
+            this.role = PartyRole.VALUES[serializer.readVarInt()];
+        }
+
+        void write(PacketSerializer serializer) {
+            serializer.writeUuid(uuid);
+            serializer.writeVarInt(role.ordinal());
+        }
+
+        public UUID getUuid() {
+            return uuid;
+        }
+
+        public PartyRole getRole() {
+            return role;
+        }
+
+        @Override
+        public String toString() {
+            return "PartyMember{" +
+                    "uuid=" + uuid +
+                    ", role=" + role +
+                    '}';
+        }
+    }
+
+    public enum PartyRole {
+        LEADER,
+        MOD,
+        MEMBER,
+        ;
+
+        private static final PartyRole[] VALUES = values();
     }
 }

--- a/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/serverbound/ServerboundPartyInfoPacket.java
@@ -3,7 +3,7 @@ package net.hypixel.modapi.packet.impl.serverbound;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
 public class ServerboundPartyInfoPacket extends ServerboundVersionedPacket {
-    private static final int CURRENT_VERSION = 1;
+    private static final int CURRENT_VERSION = 2;
 
     public ServerboundPartyInfoPacket() {
         super(CURRENT_VERSION);

--- a/src/test/java/net/hypixel/modapi/packet/handler/PartyInfoHandler.java
+++ b/src/test/java/net/hypixel/modapi/packet/handler/PartyInfoHandler.java
@@ -11,9 +11,9 @@ public class PartyInfoHandler implements PacketHandler<ServerboundPartyInfoPacke
     @Override
     public ClientboundHypixelPacket handle(String identifier, ServerboundPartyInfoPacket packet) {
         return new ClientboundPartyInfoPacket(
+                2,
                 false,
-                null,
-                Collections.emptySet()
+                Collections.emptyMap()
         );
     }
 }


### PR DESCRIPTION
Implements a version 2 of the `hypixel:party_info` packet to include member roles. 

This is the first attempt at doing a 2nd version of a packet, which will need testing of the implementation on the server. However, once Mod API has a full release, we will likely not support older versions as this is primarily for testing the version system.