### PR TITLE
added info where to look for an example implementation for fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ dependencies {
     implementation 'net.hypixel:mod-api:0.3.1'
 }
 ```
+
+## Example Mod Implementation
+Modern Fabric (1.20,...): https://github.com/ConnorLinfoot/FabricModAPIExample


### PR DESCRIPTION
Due to Hypixel wanting only trusted sources etc normally added ConnorLinfoot's example implementation for fabric (https://github.com/ConnorLinfoot/FabricModAPIExample). Did not see a Forge implementation from a "trusted" source.