### PR TITLE
change to using functional interfaces for clientbound packet handling

### DIFF
--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -130,12 +130,14 @@ public class HypixelModAPI {
         handle(packet);
     }
 
+    @SuppressWarnings("unchecked")
     public void handle(ClientboundHypixelPacket packet) {
         Collection<ClientboundPacketHandler<?>> typedHandlers = handlers.get(packet.getClass());
         // nothing registered for this packet.
         if (typedHandlers == null) return;
         for (ClientboundPacketHandler<?> handler : typedHandlers) {
-            packet.handle(handler);
+            // this cast is safe as we ensure its type when it is added to the handlers list in the first place.
+            ((ClientboundPacketHandler<ClientboundHypixelPacket>) handler).handle(packet);
         }
     }
 

--- a/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
@@ -1,25 +1,8 @@
 package net.hypixel.modapi.handler;
 
-import net.hypixel.modapi.packet.impl.clientbound.ClientboundHelloPacket;
-import net.hypixel.modapi.packet.impl.clientbound.ClientboundPartyInfoPacket;
-import net.hypixel.modapi.packet.impl.clientbound.ClientboundPingPacket;
-import net.hypixel.modapi.packet.impl.clientbound.ClientboundPlayerInfoPacket;
-import net.hypixel.modapi.packet.impl.clientbound.event.ClientboundLocationPacket;
+import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 
-public interface ClientboundPacketHandler {
-
-    default void onHelloEvent(ClientboundHelloPacket packet) {
-    }
-
-    default void onPingPacket(ClientboundPingPacket packet) {
-    }
-
-    default void onPartyInfoPacket(ClientboundPartyInfoPacket packet) {
-    }
-
-    default void onPlayerInfoPacket(ClientboundPlayerInfoPacket packet) {
-    }
-
-    default void onLocationEvent(ClientboundLocationPacket packet) {
-    }
+@FunctionalInterface
+public interface ClientboundPacketHandler<T extends ClientboundHypixelPacket> {
+    void handle(T packet);
 }

--- a/src/main/java/net/hypixel/modapi/packet/ClientboundHypixelPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/ClientboundHypixelPacket.java
@@ -1,9 +1,4 @@
 package net.hypixel.modapi.packet;
 
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
-
 public interface ClientboundHypixelPacket extends HypixelPacket {
-
-    void handle(ClientboundPacketHandler handler);
-
 }

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundHelloPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundHelloPacket.java
@@ -1,8 +1,6 @@
 package net.hypixel.modapi.packet.impl.clientbound;
 
 import net.hypixel.data.region.Environment;
-import net.hypixel.modapi.annotation.Experimental;
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
@@ -22,11 +20,6 @@ public class ClientboundHelloPacket implements ClientboundHypixelPacket {
 
         // Read any remaining bytes, so that if more data is added in the future, it will be discarded on older clients
         serializer.discardRemaining();
-    }
-
-    @Override
-    public void handle(ClientboundPacketHandler handler) {
-        handler.onHelloEvent(this);
     }
 
     @Override

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPartyInfoPacket.java
@@ -1,6 +1,5 @@
 package net.hypixel.modapi.packet.impl.clientbound;
 
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
 import java.util.*;
@@ -82,11 +81,6 @@ public class ClientboundPartyInfoPacket extends ClientboundVersionedPacket {
     @Override
     protected int getLatestVersion() {
         return CURRENT_VERSION;
-    }
-
-    @Override
-    public void handle(ClientboundPacketHandler handler) {
-        handler.onPartyInfoPacket(this);
     }
 
     public boolean isInParty() {

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPingPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPingPacket.java
@@ -1,8 +1,5 @@
 package net.hypixel.modapi.packet.impl.clientbound;
 
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
-import net.hypixel.modapi.packet.ClientboundHypixelPacket;
-import net.hypixel.modapi.packet.impl.VersionedPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
 
 public class ClientboundPingPacket extends ClientboundVersionedPacket {
@@ -38,11 +35,6 @@ public class ClientboundPingPacket extends ClientboundVersionedPacket {
     @Override
     protected int getLatestVersion() {
         return CURRENT_VERSION;
-    }
-
-    @Override
-    public void handle(ClientboundPacketHandler handler) {
-        handler.onPingPacket(this);
     }
 
     public String getResponse() {

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPlayerInfoPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/ClientboundPlayerInfoPacket.java
@@ -3,9 +3,6 @@ package net.hypixel.modapi.packet.impl.clientbound;
 import net.hypixel.data.rank.MonthlyPackageRank;
 import net.hypixel.data.rank.PackageRank;
 import net.hypixel.data.rank.PlayerRank;
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
-import net.hypixel.modapi.packet.ClientboundHypixelPacket;
-import net.hypixel.modapi.packet.impl.VersionedPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
 import org.jetbrains.annotations.Nullable;
 
@@ -57,11 +54,6 @@ public class ClientboundPlayerInfoPacket extends ClientboundVersionedPacket {
     @Override
     protected int getLatestVersion() {
         return CURRENT_VERSION;
-    }
-
-    @Override
-    public void handle(ClientboundPacketHandler handler) {
-        handler.onPlayerInfoPacket(this);
     }
 
     public PlayerRank getPlayerRank() {

--- a/src/main/java/net/hypixel/modapi/packet/impl/clientbound/event/ClientboundLocationPacket.java
+++ b/src/main/java/net/hypixel/modapi/packet/impl/clientbound/event/ClientboundLocationPacket.java
@@ -1,7 +1,6 @@
 package net.hypixel.modapi.packet.impl.clientbound.event;
 
 import net.hypixel.data.type.ServerType;
-import net.hypixel.modapi.handler.ClientboundPacketHandler;
 import net.hypixel.modapi.packet.EventPacket;
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundVersionedPacket;
 import net.hypixel.modapi.serializer.PacketSerializer;
@@ -62,11 +61,6 @@ public class ClientboundLocationPacket extends ClientboundVersionedPacket implem
     @Override
     protected int getLatestVersion() {
         return CURRENT_VERSION;
-    }
-
-    @Override
-    public void handle(ClientboundPacketHandler handler) {
-        handler.onLocationEvent(this);
     }
 
     public String getServerName() {


### PR DESCRIPTION
This PR aims to switch the current `ClientboundPacketHandler` system to using type-safe functional interfaces instead, which are specified for each packet type individually.

# Motivations
- the current system means there is a large amount of boilerplate needed if you wish to add an event handler. by utilising functional interfaces, this can be done in one line, such as `registerHandler(ClientboundPartyInfoPacket.class, packet -> partyCallback(packet))`
- the current system means that for every new packet made, more code has to be added to the `ClientboundPacketHandler` interface, which could become bothersome in the future. Each packet class also had more boilerplate which has been removed as a result.
- Prevents the `handle` method from running when it does not need to (for example, invoking a handler which does not have any implementation for `onClientHelloPacket`) which aids performance (minorly)
- (At least in my use-case), I do not use every packet available in one handler, so I can avoid writing excess implementation details.

I am, as always, open to feedback on this change. I think it is overall very good in terms of the future extensibility and cleanliness of using the API.