### PR TITLE
Add the ability to register an error handler

### DIFF
--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -2,6 +2,8 @@ package net.hypixel.modapi;
 
 import net.hypixel.modapi.error.ErrorReason;
 import net.hypixel.modapi.handler.ClientboundPacketHandler;
+import net.hypixel.modapi.handler.ErrorHandler;
+import net.hypixel.modapi.handler.RegisteredHandler;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 import net.hypixel.modapi.packet.EventPacket;
 import net.hypixel.modapi.packet.HypixelPacket;
@@ -28,7 +30,7 @@ public class HypixelModAPI {
     }
 
     private final PacketRegistry registry = new PacketRegistry();
-    private final Map<String, Collection<ClientboundPacketHandler<?>>> handlers = new ConcurrentHashMap<>();
+    private final Map<String, Collection<RegisteredHandlerImpl<?>>> handlers = new ConcurrentHashMap<>();
     private final Set<String> subscribedEvents = ConcurrentHashMap.newKeySet();
     private Set<String> lastSubscribedEvents = Collections.emptySet();
     private Predicate<HypixelPacket> packetSender = null;
@@ -124,21 +126,20 @@ public class HypixelModAPI {
     @ApiStatus.Internal
     @SuppressWarnings("unchecked")
     public void handle(ClientboundHypixelPacket packet) {
-        Collection<ClientboundPacketHandler<?>> typedHandlers = handlers.get(getRegistry().getIdentifier(packet.getClass()));
+        Collection<RegisteredHandlerImpl<?>> typedHandlers = handlers.get(getRegistry().getIdentifier(packet.getClass()));
         // nothing registered for this packet.
         if (typedHandlers == null) return;
-        for (ClientboundPacketHandler<?> handler : typedHandlers) {
-            // this cast is safe as we ensure its type when it is added to the handlers list in the first place.
-            ((ClientboundPacketHandler<ClientboundHypixelPacket>) handler).handle(packet);
+        for (RegisteredHandlerImpl<?> handler : typedHandlers) {
+            handler.handle(packet);
         }
     }
 
     @ApiStatus.Internal
     public void handleError(String identifier, ErrorReason reason) {
-        Collection<ClientboundPacketHandler<?>> handlers = this.handlers.get(identifier);
+        Collection<RegisteredHandlerImpl<?>> handlers = this.handlers.get(identifier);
         if (handlers == null) return;
-        for (ClientboundPacketHandler<?> handler : handlers) {
-            handler.onError(reason);
+        for (RegisteredHandlerImpl<?> handler : handlers) {
+            handler.handleError(reason);
         }
     }
 
@@ -150,9 +151,19 @@ public class HypixelModAPI {
         this.packetSender = packetSender;
     }
 
-    public <T extends ClientboundHypixelPacket> void registerHandler(Class<T> packetClass, ClientboundPacketHandler<T> handler) {
-        if (packetClass == null || handler == null) return;
-        handlers.computeIfAbsent(getRegistry().getIdentifier(packetClass), cls -> new CopyOnWriteArrayList<>()).add(handler);
+    public <T extends ClientboundHypixelPacket> RegisteredHandler<T> registerHandler(Class<T> packetClass, ClientboundPacketHandler<T> handler) {
+        if (packetClass == null) {
+            throw new NullPointerException("packetClass cannot be null");
+        }
+
+        if (handler == null) {
+            throw new NullPointerException("handler cannot be null");
+        }
+
+        RegisteredHandlerImpl<T> registeredHandler = new RegisteredHandlerImpl<>(handler);
+        handlers.computeIfAbsent(getRegistry().getIdentifier(packetClass), cls -> new CopyOnWriteArrayList<>())
+                .add(registeredHandler);
+        return registeredHandler;
     }
 
     public void subscribeToEventPacket(Class<? extends EventPacket> packet) {
@@ -170,5 +181,33 @@ public class HypixelModAPI {
         }
 
         return packetSender.test(packet);
+    }
+
+    private static class RegisteredHandlerImpl<T extends ClientboundHypixelPacket> implements RegisteredHandler<T> {
+        private final ClientboundPacketHandler<T> handler;
+        private ErrorHandler<T> errorHandler;
+
+        RegisteredHandlerImpl(ClientboundPacketHandler<T> handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public void onError(ErrorHandler<T> errorHandler) {
+            if (this.errorHandler != null) {
+                throw new IllegalStateException("Error handler already set");
+            }
+            this.errorHandler = errorHandler;
+        }
+
+        public void handle(ClientboundHypixelPacket packet) {
+            // this cast is safe as we ensure its type when it is added to the handlers list in the first place.
+            handler.handle((T) packet);
+        }
+
+        public void handleError(ErrorReason reason) {
+            if (errorHandler != null) {
+                errorHandler.onError(reason);
+            }
+        }
     }
 }

--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -126,7 +126,7 @@ public class HypixelModAPI {
     @ApiStatus.Internal
     @SuppressWarnings("unchecked")
     public void handle(ClientboundHypixelPacket packet) {
-        Collection<RegisteredHandlerImpl<?>> typedHandlers = handlers.get(getRegistry().getIdentifier(packet.getClass()));
+        Collection<RegisteredHandlerImpl<?>> typedHandlers = handlers.get(packet.getIdentifier());
         // nothing registered for this packet.
         if (typedHandlers == null) return;
         for (RegisteredHandlerImpl<?> handler : typedHandlers) {
@@ -199,12 +199,12 @@ public class HypixelModAPI {
             this.errorHandler = errorHandler;
         }
 
-        public void handle(ClientboundHypixelPacket packet) {
+        void handle(ClientboundHypixelPacket packet) {
             // this cast is safe as we ensure its type when it is added to the handlers list in the first place.
             handler.handle((T) packet);
         }
 
-        public void handleError(ErrorReason reason) {
+        void handleError(ErrorReason reason) {
             if (errorHandler != null) {
                 errorHandler.onError(reason);
             }

--- a/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
@@ -1,16 +1,8 @@
 package net.hypixel.modapi.handler;
 
-import net.hypixel.modapi.error.ErrorReason;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 
 @FunctionalInterface
 public interface ClientboundPacketHandler<T extends ClientboundHypixelPacket> {
     void handle(T packet);
-
-    /**
-     * Optional handling for when an error is received for this packet.
-     * <br>
-     * Note: This error may be received due to any modification requesting this packet.
-     */
-    default void onError(ErrorReason reason) {}
 }

--- a/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/ClientboundPacketHandler.java
@@ -1,8 +1,16 @@
 package net.hypixel.modapi.handler;
 
+import net.hypixel.modapi.error.ErrorReason;
 import net.hypixel.modapi.packet.ClientboundHypixelPacket;
 
 @FunctionalInterface
 public interface ClientboundPacketHandler<T extends ClientboundHypixelPacket> {
     void handle(T packet);
+
+    /**
+     * Optional handling for when an error is received for this packet.
+     * <br>
+     * Note: This error may be received due to any modification requesting this packet.
+     */
+    default void onError(ErrorReason reason) {}
 }

--- a/src/main/java/net/hypixel/modapi/handler/ErrorHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/ErrorHandler.java
@@ -1,0 +1,9 @@
+package net.hypixel.modapi.handler;
+
+import net.hypixel.modapi.error.ErrorReason;
+import net.hypixel.modapi.packet.ClientboundHypixelPacket;
+
+@FunctionalInterface
+public interface ErrorHandler<T extends ClientboundHypixelPacket> {
+    void onError(ErrorReason reason);
+}

--- a/src/main/java/net/hypixel/modapi/handler/RegisteredHandler.java
+++ b/src/main/java/net/hypixel/modapi/handler/RegisteredHandler.java
@@ -1,0 +1,12 @@
+package net.hypixel.modapi.handler;
+
+import net.hypixel.modapi.packet.ClientboundHypixelPacket;
+
+public interface RegisteredHandler<T extends ClientboundHypixelPacket> {
+    /**
+     * Handling for when an error is received for this registered handler.
+     * <br>
+     * Note: This error may be received due to any modification requesting the same packet type.
+     */
+    void onError(ErrorHandler<T> errorHandler);
+}


### PR DESCRIPTION
Changes registerHandler to return a RegisteredHandler instance, which can then be used to register handling for errors received for that packet.