### PR TITLE
Implement mod implementation interface for use in downstream mods

### DIFF
--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -34,7 +34,7 @@ public class HypixelModAPI {
     private final Set<String> subscribedEvents = ConcurrentHashMap.newKeySet();
     private Set<String> lastSubscribedEvents = Collections.emptySet();
     @Nullable
-    private HypixelModImplementation modImplementation;
+    private HypixelModAPIImplementation modImplementation;
 
     private HypixelModAPI() {
         registerHypixelPackets();
@@ -145,7 +145,7 @@ public class HypixelModAPI {
     }
 
     @ApiStatus.Internal
-    public void setModImplementation(HypixelModImplementation modImplementation) {
+    public void setModImplementation(HypixelModAPIImplementation modImplementation) {
         this.modImplementation = modImplementation;
     }
 

--- a/src/main/java/net/hypixel/modapi/HypixelModAPI.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPI.java
@@ -39,7 +39,6 @@ public class HypixelModAPI {
     private HypixelModAPI() {
         registerHypixelPackets();
         registerEventPackets();
-        registerDefaultHandler();
     }
 
     private void registerHypixelPackets() {
@@ -146,7 +145,17 @@ public class HypixelModAPI {
 
     @ApiStatus.Internal
     public void setModImplementation(HypixelModAPIImplementation modImplementation) {
+        if (this.modImplementation != null) {
+            throw new IllegalStateException("Mod implementation already set");
+        }
+
+        if (modImplementation == null) {
+            throw new NullPointerException("modImplementation cannot be null");
+        }
+
         this.modImplementation = modImplementation;
+        this.modImplementation.onInit();
+        registerDefaultHandler();
     }
 
     /**

--- a/src/main/java/net/hypixel/modapi/HypixelModAPIImplementation.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPIImplementation.java
@@ -4,7 +4,7 @@ import net.hypixel.modapi.packet.HypixelPacket;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-public interface HypixelModImplementation {
+public interface HypixelModAPIImplementation {
 
     boolean sendPacket(HypixelPacket packet);
 

--- a/src/main/java/net/hypixel/modapi/HypixelModAPIImplementation.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModAPIImplementation.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public interface HypixelModAPIImplementation {
 
+    void onInit();
+
     boolean sendPacket(HypixelPacket packet);
 
     boolean isConnectedToHypixel();

--- a/src/main/java/net/hypixel/modapi/HypixelModImplementation.java
+++ b/src/main/java/net/hypixel/modapi/HypixelModImplementation.java
@@ -1,0 +1,13 @@
+package net.hypixel.modapi;
+
+import net.hypixel.modapi.packet.HypixelPacket;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public interface HypixelModImplementation {
+
+    boolean sendPacket(HypixelPacket packet);
+
+    boolean isConnectedToHypixel();
+
+}


### PR DESCRIPTION
This change will provide better expansion moving forward for the downstream mod implementations, for now, the major addition is allowing downstream mods to track if we are connected to Hypixel to prevent sending plugin messages when we're not.